### PR TITLE
Add Plaintext hash implementation with tests

### DIFF
--- a/src/Auth/Hash.php
+++ b/src/Auth/Hash.php
@@ -40,7 +40,7 @@ abstract class Hash
      *
      * @return array<string, mixed> Hash-specific options
      */
-    protected function getOptions(): array
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/src/Auth/Hashes/Plaintext.php
+++ b/src/Auth/Hashes/Plaintext.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Utopia\Auth\Hashes;
+
+use Utopia\Auth\Hash;
+
+class Plaintext extends Hash
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function hash(string $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verify(string $value, string $hash): bool
+    {
+        return $this->hash($value) === $hash;
+    }
+}

--- a/tests/Auth/Algorithms/PlaintextTest.php
+++ b/tests/Auth/Algorithms/PlaintextTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Utopia\Tests\Auth\Hashes;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Auth\Hashes\Plaintext;
+
+class PlaintextTest extends TestCase
+{
+    protected Plaintext $plaintext;
+
+    protected function setUp(): void
+    {
+        $this->plaintext = new Plaintext();
+    }
+
+    public function testHash(): void
+    {
+        $password = 'test123';
+        $hash = $this->plaintext->hash($password);
+
+        $this->assertNotEmpty($hash);
+        $this->assertIsString($hash);
+        $this->assertEquals($password, $hash);
+        $this->assertTrue($this->plaintext->verify($password, $hash));
+        $this->assertFalse($this->plaintext->verify('wrongpassword', $hash));
+    }
+
+    public function testSpecialCharacters(): void
+    {
+        $password = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+        $hash = $this->plaintext->hash($password);
+
+        $this->assertEquals($password, $hash);
+        $this->assertTrue($this->plaintext->verify($password, $hash));
+    }
+
+    public function testUnicodeCharacters(): void
+    {
+        $password = 'Hello 世界';
+        $hash = $this->plaintext->hash($password);
+
+        $this->assertEquals($password, $hash);
+        $this->assertTrue($this->plaintext->verify($password, $hash));
+    }
+
+    public function testEmptyString(): void
+    {
+        $password = '';
+        $hash = $this->plaintext->hash($password);
+
+        $this->assertEquals($password, $hash);
+        $this->assertTrue($this->plaintext->verify($password, $hash));
+    }
+}


### PR DESCRIPTION
Implement a basic Plaintext hash algorithm that returns the original value
- Create Plaintext hash class extending Hash abstract class
- Add comprehensive test cases covering various input scenarios
- Modify Hash class to make getOptions method public